### PR TITLE
Add configurable HTTP basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Configurations can be set via flags or environment variables. To view available 
 | Configuration | Flag | Environment Variable | Default Value | Description |
 | --- | --- | --- | --- | --- |
 | Allowed hostnames | `--allowed-hostnames` | `ALLOWED_HOSTNAMES` | `"localhost"` | Comma delimited list of hostnames that are allowed to connect to the websocket |
+| Authentication | `--authentication` | `AUTHENTICATION` | `""` | If set, require this *username*:*password* using HTTP Basic Authorization |
 | Arguments | `--arguments` | `ARGUMENTS` | `"-l"` | Comma delimited list of arguments that should be passed to the target binary |
 | Command | `--command` | `COMMAND` | `"/bin/bash"` | Absolute path to the binary to run |
 | Connection error limit | `--connection-error-limit` | `CONNECTION_ERROR_LIMIT` | `10` | Number of times a connection should be re-attempted by the server to the XTerm.js frontend before the connection is considered dead and shut down |

--- a/cmd/cloudshell/config.go
+++ b/cmd/cloudshell/config.go
@@ -14,6 +14,11 @@ var conf = config.Map{
 		Usage:     "comma-delimited list of hostnames that are allowed to connect to the websocket",
 		Shorthand: "H",
 	},
+	"authentication": &config.String{
+		Default:   "",
+		Usage:     "require this username:password using HTTP Basic Authorization",
+		Shorthand: "A",
+	},
 	"arguments": &config.StringSlice{
 		Default:   []string{},
 		Usage:     "comma-delimited list of arguments that should be passed to the terminal command",

--- a/cmd/cloudshell/middleware.go
+++ b/cmd/cloudshell/middleware.go
@@ -18,3 +18,17 @@ func addIncomingRequestLogging(next http.Handler) http.Handler {
 		createRequestLog(r).Infof("request completed in %vms", float64(duration.Nanoseconds())/1000000)
 	})
 }
+
+func addAuthentication(next http.Handler, authentication string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+
+		username, password, ok := r.BasicAuth()
+		if !ok || username + ":" + password != authentication {
+		    http.Error(w, "Unauthorized", 401)
+		    return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/xtermjs/utils.go
+++ b/pkg/xtermjs/utils.go
@@ -23,7 +23,7 @@ func getConnectionUpgrader(
 					return true
 				}
 			}
-			logger.Warnf("failed to find '%s' in the list of allowed hostnames ('%s')", requesterHostname)
+			logger.Warnf("failed to find '%s' in the list of allowed hostnames ('%s')", requesterHostname, allowedHostnames)
 			return false
 		},
 		HandshakeTimeout: 0,


### PR DESCRIPTION
Add a setting which, when specified, indicates a username:password pair which will be required from HTTP clients.